### PR TITLE
TrailMod: 1.20 compat fixes

### DIFF
--- a/mods-dll/trailmod/src/Patches.cs
+++ b/mods-dll/trailmod/src/Patches.cs
@@ -47,7 +47,7 @@ namespace TrailMod
                 return;
 
             //Only run trail logic within 100 blocks of a player.
-            if (entity.minRangeToClient > 100)
+            if (entity.minHorRangeToClient > 100)
                 return;
 
             if ( entity is EntityPlayer )
@@ -60,8 +60,9 @@ namespace TrailMod
             if (world.Side == EnumAppSide.Client)
                 return;
 
+            /*
             if (!entity.Collided)
-                return;
+                return; //*/
 
             TrailChunkManager trailChunkManager = TrailChunkManager.GetTrailChunkManager();
             bool shouldTrackTrailData = trailChunkManager.ShouldTrackBlockTrailData(__instance);


### PR DESCRIPTION
- minRangeToClient is now minHorRangeToClient: replaced
- commented out entity.Collided check, as it appears to be unreliable now

I'm still not sure if removing the entity.Collided check is going to cause issues; it seemed to be fine when I was testing, at least. 